### PR TITLE
made spot click the default spot action

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Say "spot save one"
 
 Use your cursor as per usual
 
-Say "spot click one" whenever you want to click that spot
+Say "spot click one" or "spot one" whenever you want to click that spot
 
 Move your mouse somewhere new
 
 Say "spot save enemy"
 
-Say "spot enemy" whenever you want to move your mouse over that spot
+Say "spot move enemy" whenever you want to move your mouse over that spot
 
 Say "spot drag enemy" to click and drag from the current mouse position to that spot
 

--- a/screen-spots.talon
+++ b/screen-spots.talon
@@ -4,10 +4,10 @@ mode: command
 spot save <user.text>: user.save_spot(user.text)
 
 # click a saved spot then return the cursor to its prior position
-spot (click|touch) <user.text>: user.click_spot(user.text)
+spot [(click|touch)] <user.text>: user.click_spot(user.text)
 
 # move the cursor to a saved spot
-spot [move] <user.text>: user.move_to_spot(user.text)
+spot move <user.text>: user.move_to_spot(user.text)
 
 # hold left click then move the cursor to a saved spot
 spot drag <user.text>: user.drag_spot(user.text)


### PR DESCRIPTION
Previously saying "spot one" would move to the spot named one without clicking it and leave the cursor there. Now it will click on that spot and move the cursor back to its original position. The previous behavior can be accomplished with "spot move one"