### PR TITLE
improved command accuracy by implementing talon list of current spots

### DIFF
--- a/screen-spots.py
+++ b/screen-spots.py
@@ -1,7 +1,8 @@
-from talon import ctrl, Module, actions, storage, imgui, ui, canvas, settings
+from talon import ctrl, Module, actions, storage, imgui, ui, canvas, settings, Context
 from talon.skia import  Paint
 
 mod = Module()
+ctx = Context()
 
 mod.setting(
     "screen_spots_heatmap_color",
@@ -26,6 +27,11 @@ mod.setting(
 
 # Initialize with the spots in storage if there are any. All keys should be strings
 spot_dictionary = storage.get("screen-spots", {})
+ctx.lists["user.spot_list"] = list(spot_dictionary.keys())
+mod.list("spot_list", desc="List of currently set spots")
+@mod.capture(rule=("{user.spot_list}"))#return based on the current global values for spot dictionary
+def spot_list(m) -> str:
+        return (str(m))
 
 heatmap_showing = False
 
@@ -76,6 +82,9 @@ class SpotClass:
         spot_dictionary[spot_key] = [x, y]
         refresh()
         backup_spot()
+        
+        #provide this information to talon every time the list updates
+        ctx.lists["user.spot_list"] = list(spot_dictionary.keys()) 
 
     def toggle_spot_heatmap():
         """Display the spot on the screen"""
@@ -99,6 +108,9 @@ class SpotClass:
                 actions.user.slow_mouse_move(spot[0], spot[1])
             else:
                 actions.mouse_move(spot[0], spot[1])
+            
+            #flicker cursor after moving so it shows in the right place even on parsec
+            actions.user.curse_flick()
             return True
         return False
 

--- a/screen-spots.talon
+++ b/screen-spots.talon
@@ -4,21 +4,21 @@ mode: command
 spot save <user.text>: user.save_spot(user.text)
 
 # click a saved spot then return the cursor to its prior position
-spot [(click|touch)] <user.text>: user.click_spot(user.text)
+spot [(click|touch)] <user.spot_list>: user.click_spot(user.spot_list)
 
 # move the cursor to a saved spot
-spot move <user.text>: user.move_to_spot(user.text)
+spot move <user.spot_list>: user.move_to_spot(user.spot_list)
 
-# hold left click then move the cursor to a saved spot
-spot drag <user.text>: user.drag_spot(user.text)
+# hold left click then move the cursor spot_list a saved spot
+spot drag <user.spot_list>: user.drag_spot(user.text)
 
-spot swipe <user.text>: user.drag_spot(user.text, 1)
+spot swipe <user.spot_list>: user.drag_spot(user.spot_list, 1)
 
 # deletes all current spots (does not alter the cached dictionary of spots)
 spot clear all: user.clear_spot_dictionary()
 
 # delete a specific spot (does not alter the cached dictionary of spots)
-spot clear <user.text>: user.clear_spot(user.text)
+spot clear <user.spot_list>: user.clear_spot(user.spot_list)
 
 # display a list of all active spot names
 spot list [all]: user.list_spot()


### PR DESCRIPTION
I noticed a problem with mishearings of spots (ie, talon hearing "spot click clothes" and doing nothing because "close" was the spot name

This fixes that by making the current spot dictionary a list in talon, so the spot commands only act on current spots